### PR TITLE
Fix missing parentheses.

### DIFF
--- a/httpie_aws_authv4.py
+++ b/httpie_aws_authv4.py
@@ -40,10 +40,10 @@ class AWSAuth(object):
                 _, _, host, _, _, _, _ = parse_url(r.url)
                 aws_params = self._parse_url(host)
         except ValueError:
-            print "ERROR: Could not parse neccessary information from URL."
+            print("ERROR: Could not parse neccessary information from URL.")
             raise
         except Exception as error:
-            print "Error parsing URL: %s" % error
+            print("Error parsing URL: %s" % error)
             raise
 
         aws_request = AWSRequestsAuth(aws_access_key=self.aws_access_key,


### PR DESCRIPTION
For some reason, I needed to fix two pairs of parentheses to get this plug-in to work locally.
The error message I got for running "http --help" was

      File "c:\tools\python36\lib\site-packages\httpie_aws_authv4.py", line 43
        print "ERROR: Could not parse neccessary information from URL."
                                                                      ^
    SyntaxError: Missing parentheses in call to 'print'

which prompted me to "fix" it. I am on Windows with Python 3.6.0 and certainly not a Python expert, so I don't really know if my local Python install is askew or if Python (still?) requires brackets around function call arguments (I think so). But then, how can this have worked elsewhere?

Anyway, Thanks for this nice bit of code!!

I'm using it to connect to Amazon AWS ElasticSearch, too, by the way.
