### PR TITLE
Added examples to README of calling APIs which require extra parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# IntelliJ IDEs like PyCharm
+.idea

--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ $ http --auth-type aws4 --auth ACCESSKEYXXX:AWSSECRETKEYXXX:asdf123a9sas.execute
 $ http --auth-type aws4 --auth profile:XXX:asdf123a9sas.execute-api.ap-southeast-2.amazonaws.com https://api.awesomeservice.net/dev/test 
 ```
 
+### Calling AWS services that require extra information
+
+Many AWS services do not require any extra information to be passed other than the URL, such as the following call to the
+S3 service which will list all S3 Buckets in the given AWS account:
+
+```
+http -A aws4 s3.us-east-1.amazonaws.com
+```
+
+However, some AWS services will require extra information to be passed using query string parameters.  By default, ``httpie`` passes
+extra parameters as a JSON body. ``httpie`` can be told to pass extra parameters as form fields using the ``-f`` flag like so:
+
+```
+$ http -f -A aws4 ec2.us-east-1.amazonaws.com Action=DescribeVpcs Version=2015-10-01
+```
+
+where the *Action* and *Version* parameters were passed to the EC2 service to call the **DescribeVpcs** API.
+
+Alternatively instead of using the ``-f`` flag, ``==`` can be usef for each parameter like so:
+
+```
+$ http -A aws4 ec2.us-east-1.amazonaws.com Action==DescribeVpcs Version==2015-10-01
+```
+
 ## Credits
 
 All of the heavy lifting (the signing process) is handled by [aws-requests-auth](https://github.com/DavidMuller/aws-requests-auth)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ http -f -A aws4 ec2.us-east-1.amazonaws.com Action=DescribeVpcs Version=2015-1
 
 where the *Action* and *Version* parameters were passed to the EC2 service to call the **DescribeVpcs** API.
 
-Alternatively instead of using the ``-f`` flag, ``==`` can be usef for each parameter like so:
+Alternatively instead of using the ``-f`` flag, ``==`` can be used for each parameter like so:
 
 ```
 $ http -A aws4 ec2.us-east-1.amazonaws.com Action==DescribeVpcs Version==2015-10-01


### PR DESCRIPTION
Added a section at the bottom of the README called **Calling AWS services that require extra information**

Also:
- Updated *.gitignore* to add .idea directory for PyCharm/IntelliJ

This closes #5 